### PR TITLE
Revert "Correct AC_PACKAGE_NAME brackets in BDB62 m4 script"

### DIFF
--- a/build-aux/m4/bitcoin_find_bdb62.m4
+++ b/build-aux/m4/bitcoin_find_bdb62.m4
@@ -42,7 +42,7 @@ AC_DEFUN([BITCOIN_FIND_BDB62],[
   done
   if test "x$bdbpath" = "xX"; then
     AC_MSG_RESULT([no])
-    AC_MSG_ERROR([libdb_cxx headers missing,[AC_PACKAGE_NAME] requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    AC_MSG_ERROR([libdb_cxx headers missing,]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
   elif test "x$bdb62path" = "xX"; then
     BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
     AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 6.2])],[
@@ -64,7 +64,7 @@ AC_DEFUN([BITCOIN_FIND_BDB62],[
     ])
   done
   if test "x$BDB_LIBS" = "x"; then
-      AC_MSG_ERROR([libdb_cxx missing, [AC_PACKAGE_NAME] requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+      AC_MSG_ERROR([libdb_cxx missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
   fi
   AC_SUBST(BDB_LIBS)
 ])


### PR DESCRIPTION
This reverts commit 6af332f8f15c0d959e9e71a29a50dfa1397ca73f.

